### PR TITLE
:PowerAssert should require at least one argument

### DIFF
--- a/autoload/vital/__latest__/Vim/PowerAssert.vim
+++ b/autoload/vital/__latest__/Vim/PowerAssert.vim
@@ -31,7 +31,7 @@ function! s:_config() abort
 endfunction
 
 function! s:define(cmdname) abort
-  let cmd = printf("'command!' '-nargs=*' '%s' ':execute' \"%s(<q-args>)\"", a:cmdname, s:_funcname('s:assert'))
+  let cmd = printf("'command!' '-nargs=+' '%s' ':execute' \"%s(<q-args>)\"", a:cmdname, s:_funcname('s:assert'))
   return 'execute ' . cmd
 endfunction
 


### PR DESCRIPTION
`:PowerAssert` previously emitted below error on empty argument.

```
E116: Invalid arguments for function <SNR>183__assert(, '')
E15: Invalid expression: <SNR>183__assert(, '')
```

This is because `:PowerAssert` accepts no arguments.  However, at least one argument is needed to represent an expression of Vim script.  So I think `:PowerAssert` should require at least one argument.
It improves the error message as below:

```
E471: Argument required
```
