### PR TITLE
fix parsing comment for assert command

### DIFF
--- a/autoload/vital/__latest__/Vim/PowerAssert.vim
+++ b/autoload/vital/__latest__/Vim/PowerAssert.vim
@@ -457,6 +457,7 @@ function! s:_parse_cmd_trail_msg(arg) abort
   let xs = split(a:arg, '\v^.*\zs,\s*\ze([''"]).{-}\1\s*$')
   let body = xs[0]
   let quoted_msg = get(xs, 1, '')
+  " XXX: it doen't handle '' in single quote...
   let message = quoted_msg !=# '' ? quoted_msg[1:-2] : quoted_msg
   return [body, message]
 endfunction

--- a/test/PowerAssert.vimspec
+++ b/test/PowerAssert.vimspec
@@ -512,6 +512,42 @@ Describe PowerAssert
       End
     End
 
+    Describe s:_parse_cmd_trail_msg()
+      It should parse optional trailing message for :command
+        let tests = [
+        \   {
+        \      'name': 'no msg',
+        \      'in': 'x == 1',
+        \      'want': ['x == 1', ''],
+        \   },
+        \   {
+        \      'name': 'double quote',
+        \      'in': 'x == 1, "x is one (comment)"',
+        \      'want': ['x == 1', 'x is one (comment)'],
+        \   },
+        \   {
+        \      'name': '\" in "',
+        \      'in': 'x == 1, "hoge \" foo"',
+        \      'want': ['x == 1', 'hoge \" foo'],
+        \   },
+        \   {
+        \      'name': 'single quote',
+        \      'in': "x == 1, 'hoge foo'",
+        \      'want': ['x == 1', 'hoge foo'],
+        \   },
+        \   {
+        \      'name': ', in function arg',
+        \      'in': "has_key({}, 'x'), 'hoge foo'",
+        \      'want': ['has_key({}, ''x'')', 'hoge foo'],
+        \   },
+        \ ]
+        for tt in tests
+          let got = sfuncs._parse_cmd_trail_msg(tt.in)
+          Assert Equals(got, tt.want, tt.name)
+        endfor
+      End
+    End
+
   End
 
 End

--- a/test/PowerAssert.vimspec
+++ b/test/PowerAssert.vimspec
@@ -68,6 +68,12 @@ Describe PowerAssert
       execute printf('Throws /%s/ :PowerAssert index(x.ary, l:zero) is# s:two, ''%s''', msg, 'THIS IS ADDITIONAL MESSAGE')
       delcommand PowerAssert
     End
+
+    It should be parsed and handled correctly
+      execute g:PowerAssert.define('PowerAssert')
+      Throws /vital: PowerAssert: hoge foo/ :PowerAssert has_key({}, 'x'), 'hoge foo'
+      delcommand PowerAssert
+    End
   End
 
   Describe .assert

--- a/test/PowerAssert.vimspec
+++ b/test/PowerAssert.vimspec
@@ -540,6 +540,16 @@ Describe PowerAssert
         \      'in': "has_key({}, 'x'), 'hoge foo'",
         \      'want': ['has_key({}, ''x'')', 'hoge foo'],
         \   },
+        \   {
+        \      'name': 'empty string',
+        \      'in': 'x == 1, ""',
+        \      'want': ['x == 1', ''],
+        \   },
+        \   {
+        \      'name': 'quoted',
+        \      'in': "'x == 1, \"a\"'",
+        \      'want': ["'x == 1, \"a\"'", ''],
+        \   },
         \ ]
         for tt in tests
           let got = sfuncs._parse_cmd_trail_msg(tt.in)


### PR DESCRIPTION
`Assert has_key({}, 'x'), 'flags'` fails...

ref(ja): http://lingr.com/room/vim/archives/2016/08/16#message-23517665
